### PR TITLE
Added Project Operations to Core SDK via REST API

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,4 +10,7 @@ export default class Constants {
 
   /** MindsDB SQL query endpoint. */
   public static readonly BASE_SQL_URI = '/api/sql/query';
+
+  /** MindsDB Projects endpoint. */
+  public static readonly BASE_PROJECTS_URI = '/api/projects';
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
 import ModelsModule from './models/modelsModule';
+import ProjectsModule from './projects/projectsModule';
 import SQLModule from './sql/sqlModule';
 import ConnectionOptions from './connectionOptions';
 import Constants from './constants';
@@ -12,6 +13,7 @@ const defaultAxiosInstance = axios.create({
 
 const SQL = new SQLModule.SqlRestApiClient(defaultAxiosInstance);
 const Models = new ModelsModule.ModelsRestApiClient(SQL);
+const Projects = new ProjectsModule.ProjectsRestApiClient(defaultAxiosInstance);
 /**
  * Initializes the MindsDB SDK and authenticates the user if needed.
  * @param {ConnectionOptions} options - Options to use for initialization
@@ -19,6 +21,7 @@ const Models = new ModelsModule.ModelsRestApiClient(SQL);
 const connect = async function (options: ConnectionOptions): Promise<void> {
   const httpClient = options.httpClient || defaultAxiosInstance;
   SQL.client = httpClient;
+  Projects.client = httpClient;
   const baseURL =
     httpClient.defaults.baseURL || Constants.BASE_CLOUD_API_ENDPOINT;
   // Need to authenticate if we're using the Cloud API endpoints.
@@ -34,7 +37,8 @@ const connect = async function (options: ConnectionOptions): Promise<void> {
       'session'
     );
     SQL.session = session;
+    Projects.session = session;
   }
 };
 
-export default { connect, SQL, Models };
+export default { connect, SQL, Models, Projects };

--- a/src/projects/project.ts
+++ b/src/projects/project.ts
@@ -1,0 +1,5 @@
+/** Structure of a MindsDB Project. */
+export default interface Project {
+  /** Name of the project. */
+  name: string;
+}

--- a/src/projects/projectsApiClient.ts
+++ b/src/projects/projectsApiClient.ts
@@ -1,0 +1,10 @@
+import Project from './project';
+
+/** Abstract class outlining Project operations supported by the SDK. */
+export default abstract class ProjectsApiClient {
+  /**
+   * Gets all MindsDB projects for the current user.
+   * @returns {Promise<Array<Project>>} - All projects.
+   */
+  abstract getAllProjects(): Promise<Array<Project>>;
+}

--- a/src/projects/projectsModule.ts
+++ b/src/projects/projectsModule.ts
@@ -1,0 +1,3 @@
+import ProjectsRestApiClient from './projectsRestApiClient';
+
+export default { ProjectsRestApiClient };

--- a/src/projects/projectsRestApiClient.ts
+++ b/src/projects/projectsRestApiClient.ts
@@ -1,0 +1,45 @@
+import { Axios } from 'axios';
+import ProjectsApiClient from './projectsApiClient';
+import { getBaseRequestConfig } from '../util/http';
+import Constants from '../constants';
+import Project from './project';
+
+/** Implementation of ProjectsApiClient that goes through the REST API. */
+export default class ProjectsRestApiClient extends ProjectsApiClient {
+  /** Axios client to send all HTTP requests. */
+  client: Axios;
+
+  /** Session used for authentication. Used only for Cloud host. */
+  session: string | undefined;
+
+  /**
+   * Constructor for Projects API client.
+   * @param {Axios} client - Axios instance to send all HTTP requests.
+   */
+  constructor(client: Axios) {
+    super();
+    this.client = client;
+  }
+
+  private getProjectsUrl(): string {
+    const baseUrl =
+      this.client.defaults.baseURL || Constants.BASE_CLOUD_API_ENDPOINT;
+    const projectsUrl = new URL(Constants.BASE_PROJECTS_URI, baseUrl);
+    return projectsUrl.toString();
+  }
+
+  /**
+   * Gets all MindsDB projects for the current user.
+   * @returns {Promise<Array<Project>>} - All projects.
+   */
+  override async getAllProjects(): Promise<Array<Project>> {
+    const projectsResponse = await this.client.get(
+      this.getProjectsUrl(),
+      getBaseRequestConfig(this.session)
+    );
+    if (!projectsResponse.data) {
+      return [];
+    }
+    return projectsResponse.data;
+  }
+}

--- a/tests/projects/projectsRestApiClient.test.ts
+++ b/tests/projects/projectsRestApiClient.test.ts
@@ -1,0 +1,29 @@
+import axios from 'axios';
+import Constants from '../../src/constants';
+import ProjectsRestApiClient from '../../src/projects/projectsRestApiClient';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('Testing Projects REST API client', () => {
+  test('getProjects returns correct data', async () => {
+    const projectsRestApiClient = new ProjectsRestApiClient(mockedAxios);
+    // Response format of https://docs.mindsdb.com/rest/projects/get-projects.
+    const expectedProject1 = { name: 'project1' };
+    const expectedProject2 = { name: 'project2' };
+    mockedAxios.get.mockResolvedValue({
+      data: [expectedProject1, expectedProject2],
+    });
+    const actualProjects = await projectsRestApiClient.getAllProjects();
+
+    const actualUrl = mockedAxios.get.mock.calls[0][0];
+    const expectedUrl = new URL(
+      Constants.BASE_PROJECTS_URI,
+      Constants.BASE_CLOUD_API_ENDPOINT
+    ).toString();
+    expect(actualUrl).toEqual(expectedUrl);
+
+    expect(actualProjects[0]).toMatchObject(expectedProject1);
+    expect(actualProjects[1]).toMatchObject(expectedProject2);
+  });
+});


### PR DESCRIPTION
This PR adds all project operations to the core SDK using the /api/models REST API endpoint.

- Get all models

This PR depends on [another PR](https://github.com/mindsdb/mindsdb-js-sdk/pull/12)