### PR TITLE
Added Table Operations to Core SDK via REST API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import SQLModule from './sql/sqlModule';
 import ConnectionOptions from './connectionOptions';
 import Constants from './constants';
 import { getCookieValue, isMindsDbCloudEndpoint } from './util/http';
+import tablesModule from './tables/tablesModule';
 
 const defaultAxiosInstance = axios.create({
   baseURL: Constants.BASE_CLOUD_API_ENDPOINT,
@@ -14,6 +15,8 @@ const defaultAxiosInstance = axios.create({
 const SQL = new SQLModule.SqlRestApiClient(defaultAxiosInstance);
 const Models = new ModelsModule.ModelsRestApiClient(SQL);
 const Projects = new ProjectsModule.ProjectsRestApiClient(defaultAxiosInstance);
+const Tables = new tablesModule.TablesRestApiClient(SQL);
+
 /**
  * Initializes the MindsDB SDK and authenticates the user if needed.
  * @param {ConnectionOptions} options - Options to use for initialization
@@ -41,4 +44,4 @@ const connect = async function (options: ConnectionOptions): Promise<void> {
   }
 };
 
-export default { connect, SQL, Models, Projects };
+export default { connect, SQL, Models, Projects, Tables };

--- a/src/tables/table.ts
+++ b/src/tables/table.ts
@@ -1,0 +1,39 @@
+import { table } from 'console';
+import TablesApiClient from './tablesApiClient';
+
+/**
+ * Represents a MindsDB table and all supported operations.
+ */
+export default class Table {
+  /** API client to use for executing table operations. */
+  tablesApiClient: TablesApiClient;
+
+  /** Name of the table. */
+  name: string;
+
+  /** Integration the table is a part of (e.g. files, mindsdb). */
+  integration: string;
+
+  /**
+   *
+   * @param {TablesApiClient} tablesApiClient - API client to use for executing operations on this table.
+   * @param {string} name  - Name of this table.
+   * @param {string} integration - Integration the table is a part of.
+   */
+  constructor(
+    tablesApiClient: TablesApiClient,
+    name: string,
+    integration: string
+  ) {
+    this.tablesApiClient = tablesApiClient;
+    this.name = name;
+    this.integration = integration;
+  }
+
+  /**
+   * Deletes this table from its integration.
+   */
+  async delete(): Promise<void> {
+    await this.tablesApiClient.deleteTable(this.name, this.integration);
+  }
+}

--- a/src/tables/tablesApiClient.ts
+++ b/src/tables/tablesApiClient.ts
@@ -1,0 +1,40 @@
+import Table from './table';
+
+/**
+ * Abstract class outlining Table API operations supported by the SDK.
+ */
+export default abstract class TablesApiClient {
+  /**
+   * Creates a table in an integration from a given SELECT statement.
+   * @param {string} name - Name of table to be created.
+   * @param {string} integration - Name of integration the table will be a part of.
+   * @param {string} select - SELECT statement to use for populating the new table with data.
+   * @returns {Promise<Table>} - Newly created table.
+   */
+  abstract createTable(
+    name: string,
+    integration: string,
+    select: string
+  ): Promise<Table>;
+
+  /**
+   * Creates a table in an integration from a given SELECT statement. If the table already exists, it is
+   * deleted first and then recreated.
+   * @param {string} name - Name of table to be created/replaced.
+   * @param {string} integration - Name of integration the table will be a part of.
+   * @param {string} select - SELECT statement to use for populating the new/replaced table with data.
+   * @returns {Promise<Table>} - Newly created/replaced table.
+   */
+  abstract createOrReplaceTable(
+    name: string,
+    integration: string,
+    select: string
+  ): Promise<Table>;
+
+  /**
+   * Deletes a table from its integration.
+   * @param {string} name - Name of the table to be deleted.
+   * @param {string} integration - Name of the integration the table to be deleted is a part of.
+   */
+  abstract deleteTable(name: string, integration: string): Promise<void>;
+}

--- a/src/tables/tablesModule.ts
+++ b/src/tables/tablesModule.ts
@@ -1,0 +1,3 @@
+import TablesRestApiClient from './tablesRestApiClient';
+
+export default { TablesRestApiClient };

--- a/src/tables/tablesRestApiClient.ts
+++ b/src/tables/tablesRestApiClient.ts
@@ -1,0 +1,77 @@
+import SqlApiClient from '../sql/sqlApiClient';
+import Table from './table';
+import TablesApiClient from './tablesApiClient';
+import mysql from 'mysql';
+
+/** Implementation of TablesApiClient that goes through the REST API */
+export default class TablesRestApiClient extends TablesApiClient {
+  /** SQL API client to send all SQL query requests. */
+  sqlClient: SqlApiClient;
+
+  /**
+   *
+   * @param {SqlApiClient} sqlClient - SQL API client to send all SQL query requests.
+   */
+  constructor(sqlClient: SqlApiClient) {
+    super();
+    this.sqlClient = sqlClient;
+  }
+
+  /**
+   * Creates a table in an integration from a given SELECT statement.
+   * @param {string} name - Name of table to be created.
+   * @param {string} integration - Name of integration the table will be a part of.
+   * @param {string} select - SELECT statement to use for populating the new table with data.
+   * @returns {Promise<Table>} - Newly created table.
+   */
+  override async createTable(
+    name: string,
+    integration: string,
+    select: string
+  ): Promise<Table> {
+    const createClause = `CREATE TABLE ${mysql.escapeId(
+      integration
+    )}.${mysql.escapeId(name)}`;
+    const selectClause = `(${select})`;
+    const sqlQuery = [createClause, selectClause].join('\n');
+
+    await this.sqlClient.runQuery(sqlQuery);
+    return new Table(this, name, integration);
+  }
+
+  /**
+   * Creates a table in an integration from a given SELECT statement. If the table already exists, it is
+   * deleted first and then recreated.
+   * @param {string} name - Name of table to be created/replaced.
+   * @param {string} integration - Name of integration the table will be a part of.
+   * @param {string} select - SELECT statement to use for populating the new/replaced table with data.
+   * @returns {Promise<Table>} - Newly created/replaced table.
+   */
+  override async createOrReplaceTable(
+    name: string,
+    integration: string,
+    select: string
+  ): Promise<Table> {
+    const createOrReplaceClause = `CREATE OR REPLACE TABLE ${mysql.escapeId(
+      integration
+    )}.${mysql.escapeId(name)}`;
+    const selectClause = `(${select})`;
+    const sqlQuery = [createOrReplaceClause, selectClause].join('\n');
+
+    await this.sqlClient.runQuery(sqlQuery);
+    return new Table(this, name, integration);
+  }
+
+  /**
+   * Deletes a table from its integration.
+   * @param {string} name - Name of the table to be deleted.
+   * @param {string} integration - Name of the integration the table to be deleted is a part of.
+   */
+  override async deleteTable(name: string, integration: string): Promise<void> {
+    const sqlQuery = `DROP TABLE ${mysql.escapeId(
+      integration
+    )}.${mysql.escapeId(name)}`;
+
+    await this.sqlClient.runQuery(sqlQuery);
+  }
+}

--- a/tests/tables/tablesRestApiClient.test.ts
+++ b/tests/tables/tablesRestApiClient.test.ts
@@ -1,0 +1,92 @@
+import axios from 'axios';
+
+import TablesRestApiClient from '../../src/tables/tablesRestApiClient';
+import SqlRestApiClient from '../../src/sql/sqlRestApiClient';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+jest.mock('../../src/sql/sqlRestApiClient');
+const mockedSqlRestApiClient = new SqlRestApiClient(
+  mockedAxios
+) as jest.Mocked<SqlRestApiClient>;
+
+describe('Testing Models REST API client', () => {
+  afterEach(() => {
+    mockedSqlRestApiClient.runQuery.mockClear();
+  });
+  test('should create table', async () => {
+    const tablesRestApiClient = new TablesRestApiClient(mockedSqlRestApiClient);
+    mockedSqlRestApiClient.runQuery.mockImplementation(() => {
+      return Promise.resolve({
+        columnNames: [],
+        context: {
+          db: 'mindsdb',
+        },
+        type: 'ok',
+        rows: [],
+      });
+    });
+
+    const table = await tablesRestApiClient.createTable(
+      'my_table',
+      'my_integration',
+      'SELECT * FROM other_integration.other_table'
+    );
+
+    const actualQuery = mockedSqlRestApiClient.runQuery.mock.calls[0][0];
+    const expectedQuery = `CREATE TABLE \`my_integration\`.\`my_table\`
+(SELECT * FROM other_integration.other_table)`;
+    expect(actualQuery).toEqual(expectedQuery);
+
+    expect(table.name).toEqual('my_table');
+    expect(table.integration).toEqual('my_integration');
+  });
+
+  test('should create or replace table', async () => {
+    const tablesRestApiClient = new TablesRestApiClient(mockedSqlRestApiClient);
+    mockedSqlRestApiClient.runQuery.mockImplementation(() => {
+      return Promise.resolve({
+        columnNames: [],
+        context: {
+          db: 'mindsdb',
+        },
+        type: 'ok',
+        rows: [],
+      });
+    });
+
+    const table = await tablesRestApiClient.createOrReplaceTable(
+      'my_table',
+      'my_integration',
+      'SELECT * FROM other_integration.other_table'
+    );
+
+    const actualQuery = mockedSqlRestApiClient.runQuery.mock.calls[0][0];
+    const expectedQuery = `CREATE OR REPLACE TABLE \`my_integration\`.\`my_table\`
+(SELECT * FROM other_integration.other_table)`;
+    expect(actualQuery).toEqual(expectedQuery);
+
+    expect(table.name).toEqual('my_table');
+    expect(table.integration).toEqual('my_integration');
+  });
+
+  test('should delete table', async () => {
+    const tablesRestApiClient = new TablesRestApiClient(mockedSqlRestApiClient);
+    mockedSqlRestApiClient.runQuery.mockImplementation(() => {
+      return Promise.resolve({
+        columnNames: [],
+        context: {
+          db: 'mindsdb',
+        },
+        type: 'ok',
+        rows: [],
+      });
+    });
+
+    await tablesRestApiClient.deleteTable('my_table', 'my_integration');
+
+    const actualQuery = mockedSqlRestApiClient.runQuery.mock.calls[0][0];
+    const expectedQuery = `DROP TABLE \`my_integration\`.\`my_table\``;
+    expect(actualQuery).toEqual(expectedQuery);
+  });
+});


### PR DESCRIPTION
This PR adds all table operations to the core SDK, proxying through the SQL REST API.

- Create a table
- Create/replace table
- Delete a table

After a table is created, users can query it through the SQL.runQuery(...) method, or include it in any SELECT statement to be used with other SDK operations.

This PR depends on [another PR](https://github.com/mindsdb/mindsdb-js-sdk/pull/13)