### PR TITLE
Implement HTTP Connection Pooling With Axios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,13 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@types/mysql": "^2.15.21",
+        "agentkeepalive": "^4.2.1",
         "axios": "^1.3.2",
         "mysql": "^2.18.1"
       },
       "devDependencies": {
         "@types/jest": "^29.4.0",
+        "@types/mysql": "^2.15.21",
         "@typescript-eslint/eslint-plugin": "^5.51.0",
         "@typescript-eslint/parser": "^5.51.0",
         "eslint": "^8.33.0",
@@ -1294,6 +1295,7 @@
       "version": "2.15.21",
       "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.21.tgz",
       "integrity": "sha512-NPotx5CVful7yB+qZbWtXL2fA4e7aEHkihHLjklc6ID8aq7bhguHgeIoC1EmSNTAuCgI6ZXrjt2ZSaXnYX0EUg==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -1301,7 +1303,8 @@
     "node_modules/@types/node": {
       "version": "18.11.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.19.tgz",
-      "integrity": "sha512-YUgMWAQBWLObABqrvx8qKO1enAvBUdjZOAWQ5grBAkp5LQv45jBvYKZ3oFS9iKRCQyFjqw6iuEa1vmFqtxYLZw=="
+      "integrity": "sha512-YUgMWAQBWLObABqrvx8qKO1enAvBUdjZOAWQ5grBAkp5LQv45jBvYKZ3oFS9iKRCQyFjqw6iuEa1vmFqtxYLZw==",
+      "dev": true
     },
     "node_modules/@types/prettier": {
       "version": "2.7.2",
@@ -1543,6 +1546,19 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
+      "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "depd": "^1.1.2",
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -2011,7 +2027,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -2051,6 +2066,14 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/detect-newline": {
@@ -2759,6 +2782,14 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/ignore": {
@@ -3817,8 +3848,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/mysql": {
       "version": "2.18.1",
@@ -5933,6 +5963,7 @@
       "version": "2.15.21",
       "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.21.tgz",
       "integrity": "sha512-NPotx5CVful7yB+qZbWtXL2fA4e7aEHkihHLjklc6ID8aq7bhguHgeIoC1EmSNTAuCgI6ZXrjt2ZSaXnYX0EUg==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -5940,7 +5971,8 @@
     "@types/node": {
       "version": "18.11.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.19.tgz",
-      "integrity": "sha512-YUgMWAQBWLObABqrvx8qKO1enAvBUdjZOAWQ5grBAkp5LQv45jBvYKZ3oFS9iKRCQyFjqw6iuEa1vmFqtxYLZw=="
+      "integrity": "sha512-YUgMWAQBWLObABqrvx8qKO1enAvBUdjZOAWQ5grBAkp5LQv45jBvYKZ3oFS9iKRCQyFjqw6iuEa1vmFqtxYLZw==",
+      "dev": true
     },
     "@types/prettier": {
       "version": "2.7.2",
@@ -6086,6 +6118,16 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
+    },
+    "agentkeepalive": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
+      "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
+      "requires": {
+        "debug": "^4.1.0",
+        "depd": "^1.1.2",
+        "humanize-ms": "^1.2.1"
+      }
     },
     "ajv": {
       "version": "6.12.6",
@@ -6428,7 +6470,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -6455,6 +6496,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -6975,6 +7021,14 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true
+    },
+    "humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "requires": {
+        "ms": "^2.0.0"
+      }
     },
     "ignore": {
       "version": "5.2.4",
@@ -7777,8 +7831,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mysql": {
       "version": "2.18.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/jest": "^29.4.0",
+    "@types/mysql": "^2.15.21",
     "@typescript-eslint/eslint-plugin": "^5.51.0",
     "@typescript-eslint/parser": "^5.51.0",
     "eslint": "^8.33.0",
@@ -26,10 +27,10 @@
     "jest": "^29.4.1",
     "prettier": "^2.8.3",
     "ts-jest": "^29.0.5",
-    "typescript": "^4.9.5",
-    "@types/mysql": "^2.15.21"
+    "typescript": "^4.9.5"
   },
   "dependencies": {
+    "agentkeepalive": "^4.2.1",
     "axios": "^1.3.2",
     "mysql": "^2.18.1"
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,4 +13,21 @@ export default class Constants {
 
   /** MindsDB Projects endpoint. */
   public static readonly BASE_PROJECTS_URI = '/api/projects';
+
+  // HTTP agent constants.
+
+  /** How long to wait for an HTTP response before timeout. */
+  public static readonly DEFAULT_HTTP_TIMEOUT_MS = 60 * 1000;
+
+  /** Maximum number of socket connections per host. */
+  public static readonly DEFAULT_MAX_SOCKETS_PER_HOST = 128;
+
+  /** Maximum number of sockets per host to leave open in a free state. */
+  public static readonly DEFAULT_MAX_FREE_SOCKETS = 128;
+
+  /** Timeout active sockets after this period of inactivity. */
+  public static readonly DEFAULT_ACTIVE_SOCKET_TIMEOUT_MS = 60 * 1000;
+
+  /** Timeout free sockets after this period of inactivity. */
+  public static readonly DEFAULT_FREE_SOCKET_TIMEOUT_MS = 30 * 1000;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,12 +7,14 @@ import SQLModule from './sql/sqlModule';
 import ViewsModule from './views/viewsModule';
 import ConnectionOptions from './connectionOptions';
 import Constants from './constants';
-import { getCookieValue, isMindsDbCloudEndpoint } from './util/http';
+import {
+  createDefaultAxiosInstance,
+  getCookieValue,
+  isMindsDbCloudEndpoint,
+} from './util/http';
 import TablesModule from './tables/tablesModule';
 
-const defaultAxiosInstance = axios.create({
-  baseURL: Constants.BASE_CLOUD_API_ENDPOINT,
-});
+const defaultAxiosInstance = createDefaultAxiosInstance();
 
 const SQL = new SQLModule.SqlRestApiClient(defaultAxiosInstance);
 const Databases = new DatabasesModule.DatabasesRestApiClient(SQL);

--- a/src/util/http.ts
+++ b/src/util/http.ts
@@ -1,5 +1,31 @@
-import { AxiosRequestConfig } from 'axios';
+import axios, { Axios, AxiosRequestConfig } from 'axios';
+import Agent, { HttpsAgent } from 'agentkeepalive';
+import Constants from '../constants';
 
+/**
+ * Creates the default Axios instance to use for all SDK HTTP requests.
+ * @returns {Axios} - Axios instance with sensible defaults.
+ */
+function createDefaultAxiosInstance(): Axios {
+  const keepAliveAgent = new Agent({
+    maxSockets: Constants.DEFAULT_MAX_SOCKETS_PER_HOST,
+    maxFreeSockets: Constants.DEFAULT_MAX_FREE_SOCKETS,
+    timeout: Constants.DEFAULT_ACTIVE_SOCKET_TIMEOUT_MS,
+    freeSocketTimeout: Constants.DEFAULT_FREE_SOCKET_TIMEOUT_MS,
+  });
+  const httpsKeepAliveAgent = new HttpsAgent({
+    maxSockets: Constants.DEFAULT_MAX_SOCKETS_PER_HOST,
+    maxFreeSockets: Constants.DEFAULT_MAX_FREE_SOCKETS,
+    timeout: Constants.DEFAULT_ACTIVE_SOCKET_TIMEOUT_MS,
+    freeSocketTimeout: Constants.DEFAULT_FREE_SOCKET_TIMEOUT_MS,
+  });
+  return axios.create({
+    baseURL: Constants.BASE_CLOUD_API_ENDPOINT,
+    timeout: Constants.DEFAULT_HTTP_TIMEOUT_MS,
+    httpAgent: keepAliveAgent,
+    httpsAgent: httpsKeepAliveAgent,
+  });
+}
 /**
  * Gets the base HTTP request config to use for all REST API requests.
  * @param {string | undefined} session - Session to use for authentication. Only used for Cloud endpoints.
@@ -52,4 +78,9 @@ function isMindsDbCloudEndpoint(url: string): boolean {
   return url.includes('mindsdb.com');
 }
 
-export { getBaseRequestConfig, getCookieValue, isMindsDbCloudEndpoint };
+export {
+  createDefaultAxiosInstance,
+  getBaseRequestConfig,
+  getCookieValue,
+  isMindsDbCloudEndpoint,
+};


### PR DESCRIPTION
We will use [agentkeepalive](https://www.npmjs.com/package/agentkeepalive) to create HTTP/HTTPS agents to use with Axios that implement connection pooling. The default Axios instance should work for most users with sensible defaults. As always, users can provide a custom Axios instance using their own connection pooling if they have custom needs.

This PR depends on [another PR](https://github.com/mindsdb/mindsdb-js-sdk/pull/20)