### PR TITLE
Make integration and trainingOptions optional when retraining 

### DIFF
--- a/src/models/modelsApiClient.ts
+++ b/src/models/modelsApiClient.ts
@@ -111,14 +111,14 @@ export default abstract class ModelsApiClient {
    * Partially adjusts this model with the given options.
    * @param {string} name - Name of the model.
    * @param {string} project - Project the model belongs to.
-   * @param {string} integration - Integration name for the training data (e.g. mindsdb).
-   * @param {AdjustOptions} options - Options to use when adjusting the model.
+   * @param {string} [integration] - Integration name for the training data (e.g. mindsdb).
+   * @param {AdjustOptions} [options] - Options to use when adjusting the model.
    * @throws {MindsDbError} - Something went wrong adjusting the model.
    */
   abstract adjustModel(
     name: string,
     project: string,
-    integration: string,
-    options: AdjustOptions
+    integration?: string,
+    options?: AdjustOptions
   ): Promise<void>;
 }


### PR DESCRIPTION
This is to simulate the 'RETRAIN project_name.predictor_name' command with no additional arguments.