### PR TITLE
Handle reauthentication properly using Axios response interceptor and new HttpAuthenticator Class

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mindsdb-js-sdk",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "author": "MindsDB",
   "license": "MIT",
   "description": "Official JavaScript SDK for MindsDB",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -79,6 +79,20 @@ class MindsDbError extends Error {
     }
     return new MindsDbError(axiosError.message);
   }
+
+  /**
+   * Creates a MindsDB error from an error thrown during an HTTP request, with a more readable error message.
+   * @param {AxiosError} axiosError - Original HTTP Error
+   * @returns {MindsDbError} - New MindsDB error.
+   */
+  static fromHttpError(error: unknown, url: string): MindsDbError {
+    if (error instanceof AxiosError) {
+      return MindsDbError.fromAxiosError(error);
+    }
+    return new MindsDbError(
+      `Something went wrong handling HTTP POST request to ${url}: ${error}`
+    );
+  }
 }
 
 export { MindsDbError };

--- a/src/httpAuthenticator.ts
+++ b/src/httpAuthenticator.ts
@@ -1,0 +1,70 @@
+import { Axios, AxiosError, HttpStatusCode } from 'axios';
+import Constants from './constants';
+import { getCookieValue } from './util/http';
+
+/** Handles HTTP authentication and reauthentication for MindsDB Cloud. */
+export default class HttpAuthenticator {
+  /** Session used for authentication. */
+  session: string | undefined;
+
+  /** MindsDB email used for authentication. */
+  user = '';
+
+  /** MindsDB password used for authentication. */
+  password = '';
+
+  /**
+   * Logs into MindsDB Cloud and stores the returned session.
+   * @param {Axios} axiosClient - Axios instance to use when sending login request.
+   * @param {string} user - MindsDB email to use for logging in.
+   * @param {string} password - MindsDB password to use for logging in.
+   */
+  async authenticate(
+    axiosClient: Axios,
+    user: string,
+    password: string
+  ): Promise<void> {
+    this.user = user;
+    this.password = password;
+    const baseURL =
+      axiosClient.defaults.baseURL || Constants.BASE_CLOUD_API_ENDPOINT;
+    const loginURL = new URL(Constants.BASE_LOGIN_URI, baseURL);
+    const loginResponse = await axiosClient.post(loginURL.href, {
+      email: this.user,
+      password: this.password,
+    });
+    this.session = getCookieValue(
+      loginResponse.headers['set-cookie'] || [],
+      'session'
+    );
+  }
+
+  /**
+   *
+   * @param {Axios} axiosClient - Axios instance to use when sending login request.
+   * @param {any} error - Original error to inspect for determining if we need to reauthenticate.
+   * @returns - True if we successfully reauthenticated, false if not needed.
+   */
+  async handleReauthentication(
+    axiosClient: Axios,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    error: any
+  ): Promise<boolean> {
+    if (!this.session || !error) {
+      // We never needed to authenticate to begin with.
+      return false;
+    }
+    if (
+      !error.response ||
+      (error.response.status != HttpStatusCode.Unauthorized &&
+        error.response.status != HttpStatusCode.Forbidden)
+    ) {
+      // Only reauthenticate for 401/403 responses.
+      return false;
+    }
+    console.info('MindsDB HTTP session expired. Reauthenticating...');
+    await this.authenticate(axiosClient, this.user, this.password);
+    console.info('Successfully reauthenticated.');
+    return true;
+  }
+}

--- a/tests/databases/databasesRestApiClient.test.ts
+++ b/tests/databases/databasesRestApiClient.test.ts
@@ -1,12 +1,17 @@
 import axios from 'axios';
 import DatabasesRestApiClient from '../../src/databases/databasesRestApiClient';
+import HttpAuthenticator from '../../src/httpAuthenticator';
 import SqlRestApiClient from '../../src/sql/sqlRestApiClient';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
+jest.mock('../../src/httpAuthenticator');
+const mockedHttpAuthenticator =
+  new HttpAuthenticator() as jest.Mocked<HttpAuthenticator>;
 jest.mock('../../src/sql/sqlRestApiClient');
 const mockedSqlRestApiClient = new SqlRestApiClient(
-  mockedAxios
+  mockedAxios,
+  mockedHttpAuthenticator
 ) as jest.Mocked<SqlRestApiClient>;
 
 describe('Testing Databases REST API client', () => {

--- a/tests/httpAuthenticator.test.ts
+++ b/tests/httpAuthenticator.test.ts
@@ -1,0 +1,65 @@
+import axios, { AxiosError, HttpStatusCode } from 'axios';
+import HttpAuthenticator from '../src/httpAuthenticator';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('Testing HTTP Authenticator', () => {
+  function makeAxiosError(code: HttpStatusCode): AxiosError {
+    return {
+      message: 'Test message',
+      code: '',
+      config: { headers: {} },
+      request: undefined,
+      response: { status: code },
+    } as AxiosError;
+  }
+  test('reauthenticates for 401 requests', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      headers: {
+        // MindsDB Cloud login always returns a session cookie in response headers.
+        'set-cookie': ['session=new-session; Domain=.mindsdb.com; Path=/'],
+      },
+    });
+
+    const authenticator = new HttpAuthenticator();
+    authenticator.session = 'old-session';
+    const unauthError = makeAxiosError(HttpStatusCode.Unauthorized);
+
+    const reauthenticated = await authenticator.handleReauthentication(
+      mockedAxios,
+      unauthError
+    );
+    expect(reauthenticated).toBe(true);
+  });
+  test('reauthenticates for 403 requests', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      headers: {
+        // MindsDB Cloud login always returns a session cookie in response headers.
+        'set-cookie': ['session=new-session; Domain=.mindsdb.com; Path=/'],
+      },
+    });
+
+    const authenticator = new HttpAuthenticator();
+    authenticator.session = 'old-session';
+    const unauthError = makeAxiosError(HttpStatusCode.Forbidden);
+
+    const reauthenticated = await authenticator.handleReauthentication(
+      mockedAxios,
+      unauthError
+    );
+    expect(reauthenticated).toBe(true);
+    expect(authenticator.session).toEqual('new-session');
+  });
+  test('does not reauthenticate for irrelevant errors', async () => {
+    const authenticator = new HttpAuthenticator();
+    authenticator.session = 'old-session';
+    const internalError = makeAxiosError(HttpStatusCode.InternalServerError);
+
+    const reauthenticated = await authenticator.handleReauthentication(
+      mockedAxios,
+      internalError
+    );
+    expect(reauthenticated).toBe(false);
+  });
+});

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -37,12 +37,12 @@ describe('Testing root SDK functions', () => {
       password: 'test-password',
     });
 
-    expect(MindsDB.SQL.session).toEqual('test-session');
+    expect(MindsDB.SQL.authenticator.session).toEqual('test-session');
   });
 
   test('connect should not authenticate for custom endpoint', async () => {
-    mockedAxios.defaults.baseURL = 'https://test-url.com';
     await MindsDB.connect({
+      host: 'https://test-url.com',
       user: 'test-user',
       password: 'test-password',
       httpClient: mockedAxios,

--- a/tests/models/modelsRestApiClient.test.ts
+++ b/tests/models/modelsRestApiClient.test.ts
@@ -1,18 +1,19 @@
 import axios from 'axios';
-import {
-  Model,
-  ModelFeatureDescription,
-  ModelPrediction,
-} from '../../src/models/model';
+import { Model, ModelPrediction } from '../../src/models/model';
 import ModelsRestApiClient from '../../src/models/modelsRestApiClient';
-import SqlQueryResult from '../../src/sql/sqlQueryResult';
 import SqlRestApiClient from '../../src/sql/sqlRestApiClient';
+import HttpAuthenticator from '../../src/httpAuthenticator';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+jest.mock('../../src/httpAuthenticator');
+const mockedHttpAuthenticator =
+  new HttpAuthenticator() as jest.Mocked<HttpAuthenticator>;
 jest.mock('../../src/sql/sqlRestApiClient');
 const mockedSqlRestApiClient = new SqlRestApiClient(
-  mockedAxios
+  mockedAxios,
+  mockedHttpAuthenticator
 ) as jest.Mocked<SqlRestApiClient>;
 
 describe('Testing Models REST API client', () => {

--- a/tests/projects/projectsRestApiClient.test.ts
+++ b/tests/projects/projectsRestApiClient.test.ts
@@ -1,13 +1,21 @@
 import axios from 'axios';
 import Constants from '../../src/constants';
+import HttpAuthenticator from '../../src/httpAuthenticator';
 import ProjectsRestApiClient from '../../src/projects/projectsRestApiClient';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
+jest.mock('../../src/httpAuthenticator');
+const mockedHttpAuthenticator =
+  new HttpAuthenticator() as jest.Mocked<HttpAuthenticator>;
+
 describe('Testing Projects REST API client', () => {
   test('getProjects returns correct data', async () => {
-    const projectsRestApiClient = new ProjectsRestApiClient(mockedAxios);
+    const projectsRestApiClient = new ProjectsRestApiClient(
+      mockedAxios,
+      mockedHttpAuthenticator
+    );
     // Response format of https://docs.mindsdb.com/rest/projects/get-projects.
     const expectedProject1 = { name: 'project1' };
     const expectedProject2 = { name: 'project2' };

--- a/tests/sql/sqlRestApiClient.test.ts
+++ b/tests/sql/sqlRestApiClient.test.ts
@@ -1,13 +1,21 @@
 import axios from 'axios';
 import Constants from '../../src/constants';
+import HttpAuthenticator from '../../src/httpAuthenticator';
 import SqlRestApiClient from '../../src/sql/sqlRestApiClient';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
+jest.mock('../../src/httpAuthenticator');
+const mockedHttpAuthenticator =
+  new HttpAuthenticator() as jest.Mocked<HttpAuthenticator>;
+
 describe('Testing SQL REST API client', () => {
   test('runQuery returns correct data', async () => {
-    const restApiClient = new SqlRestApiClient(mockedAxios);
+    const restApiClient = new SqlRestApiClient(
+      mockedAxios,
+      mockedHttpAuthenticator
+    );
     // Response format of https://docs.mindsdb.com/rest/sql.
     mockedAxios.post.mockResolvedValue({
       data: {

--- a/tests/tables/tablesRestApiClient.test.ts
+++ b/tests/tables/tablesRestApiClient.test.ts
@@ -2,12 +2,17 @@ import axios from 'axios';
 
 import TablesRestApiClient from '../../src/tables/tablesRestApiClient';
 import SqlRestApiClient from '../../src/sql/sqlRestApiClient';
+import HttpAuthenticator from '../../src/httpAuthenticator';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
+jest.mock('../../src/httpAuthenticator');
+const mockedHttpAuthenticator =
+  new HttpAuthenticator() as jest.Mocked<HttpAuthenticator>;
 jest.mock('../../src/sql/sqlRestApiClient');
 const mockedSqlRestApiClient = new SqlRestApiClient(
-  mockedAxios
+  mockedAxios,
+  mockedHttpAuthenticator
 ) as jest.Mocked<SqlRestApiClient>;
 
 describe('Testing Models REST API client', () => {

--- a/tests/util/http.test.ts
+++ b/tests/util/http.test.ts
@@ -1,21 +1,46 @@
+import axios, { AxiosError, AxiosResponse, HttpStatusCode } from 'axios';
+import HttpAuthenticator from '../../src/httpAuthenticator';
 import {
   getCookieValue,
   getBaseRequestConfig,
   isMindsDbCloudEndpoint,
+  retryUnauthenticatedRequest,
 } from '../../src/util/http';
 
+jest.mock('../../src/httpAuthenticator');
+const mockedHttpAuthenticator =
+  new HttpAuthenticator() as jest.Mocked<HttpAuthenticator>;
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
 describe('Testing HTTP utils', () => {
+  function makeAxiosError(code: HttpStatusCode): AxiosError {
+    return {
+      message: 'Test message',
+      code: '',
+      config: { headers: {} },
+      request: undefined,
+      response: { status: code },
+    } as AxiosError;
+  }
+
+  afterEach(() => {
+    mockedAxios.request.mockClear();
+    mockedHttpAuthenticator.handleReauthentication.mockClear();
+  });
+
   test('getBaseRequestConfig should include cookie header with session', () => {
-    const session = 'test-session';
-    expect(getBaseRequestConfig(session)).toMatchObject({
+    mockedHttpAuthenticator.session = 'test-session';
+    expect(getBaseRequestConfig(mockedHttpAuthenticator)).toMatchObject({
       headers: {
         Cookie: 'session=test-session',
       },
     });
   });
   test('getBaseRequestConfig should not include cookie header if session undefined', () => {
-    const session = undefined;
-    expect(getBaseRequestConfig(session)).toMatchObject({});
+    mockedHttpAuthenticator.session = undefined;
+    expect(getBaseRequestConfig(mockedHttpAuthenticator)).toMatchObject({});
   });
   test('getCookieValue gets value of session cookie', () => {
     const allCookies = [
@@ -36,5 +61,43 @@ describe('Testing HTTP utils', () => {
   });
   test('isMindsDbCloudEndpoint returns false for local endpoint', () => {
     expect(isMindsDbCloudEndpoint('https://127.0.0.1')).toBeFalsy();
+  });
+  test('retryUnauthenticatedRequest retries when needed', async () => {
+    const unauthenticatedError = makeAxiosError(HttpStatusCode.Unauthorized);
+    mockedHttpAuthenticator.handleReauthentication.mockResolvedValueOnce(true);
+    mockedHttpAuthenticator.session = 'new-session';
+    const expectedResponse = {
+      data: ['test-data'],
+      status: HttpStatusCode.Ok,
+    } as AxiosResponse;
+
+    mockedAxios.request.mockResolvedValueOnce(expectedResponse);
+
+    const actualResponse = await retryUnauthenticatedRequest(
+      unauthenticatedError,
+      mockedAxios,
+      mockedHttpAuthenticator
+    );
+
+    expect(mockedAxios.request).toHaveBeenCalled();
+
+    const actualRequestConfig = mockedAxios.request.mock.calls[0][0];
+    // We used the new session for the request.
+    const headers = actualRequestConfig.headers || {};
+
+    expect(headers['Cookie']).toEqual(`session=new-session`);
+    expect(actualResponse).toMatchObject(expectedResponse);
+  });
+  test('retryUnauthenticatedRequest does not retry when not needed', async () => {
+    const internalError = makeAxiosError(HttpStatusCode.ServiceUnavailable);
+    mockedHttpAuthenticator.handleReauthentication.mockResolvedValueOnce(false);
+
+    const retryPromise = retryUnauthenticatedRequest(
+      internalError,
+      mockedAxios,
+      mockedHttpAuthenticator
+    );
+    await expect(retryPromise).rejects.toMatchObject(internalError);
+    expect(mockedAxios.request).not.toHaveBeenCalled();
   });
 });

--- a/tests/views/viewsRestApiClient.test.ts
+++ b/tests/views/viewsRestApiClient.test.ts
@@ -1,12 +1,17 @@
 import axios from 'axios';
 import ViewsRestApiClient from '../../src/views/viewsRestApiClient';
 import SqlRestApiClient from '../../src/sql/sqlRestApiClient';
+import HttpAuthenticator from '../../src/httpAuthenticator';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
+jest.mock('../../src/httpAuthenticator');
+const mockedHttpAuthenticator =
+  new HttpAuthenticator() as jest.Mocked<HttpAuthenticator>;
 jest.mock('../../src/sql/sqlRestApiClient');
 const mockedSqlRestApiClient = new SqlRestApiClient(
-  mockedAxios
+  mockedAxios,
+  mockedHttpAuthenticator
 ) as jest.Mocked<SqlRestApiClient>;
 
 describe('Testing Views REST API client', () => {


### PR DESCRIPTION
When a request fails with 401 (unauthorized) or 403 (forbidden) error code, now we try to reauthenticate, and retry the original request once. If the request fails more than once we rethrow the original error.

Tested this manually too.