### PR TITLE
fix(tables): Resolve compilation errors in table-related classes

### DIFF
--- a/src/tables/table.ts
+++ b/src/tables/table.ts
@@ -72,8 +72,8 @@ export default class Table {
    async  update(updateQuery: string): Promise<void> {
     await this.tablesApiClient.updateTable(this.name, this.integration,updateQuery);
    }
-}
 
+  /**
    * Insert data into this table.
    * @param {string} select - SELECT query to insert data from.
    * @throws {MindsDbError} - Something went wrong inserting data into the table.
@@ -82,4 +82,3 @@ export default class Table {
     await this.tablesApiClient.insertTable(this.name, this.integration, select);
   }
 }
-

--- a/src/tables/tablesApiClient.ts
+++ b/src/tables/tablesApiClient.ts
@@ -42,6 +42,14 @@ export default abstract class TablesApiClient {
   abstract deleteTable(name: string, integration: string): Promise<void>;
 
   /**
+   * Removes a table from its integration.
+   * @param {string} name - Name of the table to be removed.
+   * @param {string} integration - Name of the integration the table to be removed is a part of.
+   * @throws {MindsDbError} - Something went wrong removing the table.
+   */
+  abstract removeTable(name: string, integration: string): Promise<void>;
+
+  /**
    * Updates a table from its integration.
    * @param {string} name - Name of the table to be updated.
    * @param {string} integration - Name of the integration the table to be updated is a part of.
@@ -84,11 +92,9 @@ export default abstract class TablesApiClient {
    *
    * @param filePath - The local path to the file that needs to be uploaded.
    * @param fileName - The name that the file should have on the remote server after the upload.
-   * 
-   * @returns A promise that resolves when the file has been successfully uploaded.
-   *          The promise does not return any value upon success.
-   * 
-   * @throws {Error} - If there is an error during the file upload process, the promise is rejected with an error message.
+   * * @returns A promise that resolves when the file has been successfully uploaded.
+   * The promise does not return any value upon success.
+   * * @throws {Error} - If there is an error during the file upload process, the promise is rejected with an error message.
    */
   abstract uploadFile(filePath: string, fileName: string, original_file_name?: string): Promise<void>;
 }

--- a/src/tables/tablesRestApiClient.ts
+++ b/src/tables/tablesRestApiClient.ts
@@ -109,6 +109,17 @@ export default class TablesRestApiClient extends TablesApiClient {
 
 
   /**
+   * Removes a table from its integration.
+   * @param {string} name - Name of the table to be removed.
+   * @param {string} integration - Name of the integration the table to be removed is a part of.
+   * @throws {MindsDbError} - Something went wrong removing the table.
+   */
+  override async removeTable(name: string, integration: string): Promise<void> {
+    await this.deleteTable(name, integration);
+  }
+
+
+  /**
    * Updates a table from its integration.
    * @param {string} name - Name of the table to be updated.
    * @param {string} integration - Name of the integration the table to be updated is a part of.
@@ -149,8 +160,7 @@ export default class TablesRestApiClient extends TablesApiClient {
    * @throws {MindsDbError} - Something went wrong deleting the data from the table.
    */
   override async deleteFromTable(name: string, integration: string, select?: string): Promise<void> {
-    /** 
-    If select parameter is not passed then entire data from the table is deleted.
+    /** If select parameter is not passed then entire data from the table is deleted.
     */
     const sqlQuery = select ?? `DELETE FROM TABLE ${mysql.escapeId(
       integration
@@ -214,8 +224,7 @@ export default class TablesRestApiClient extends TablesApiClient {
    * @param {string} fileName - The desired name for the file once it is uploaded.
    * @param {string} [original_file_name] - (Optional) The original name of the file before renaming. This is typically
    * used for logging, tracking, or maintaining the original file's identity.
-   * 
-   * @returns {Promise<void>} A promise that resolves when the file upload is complete. If the upload fails,
+   * * @returns {Promise<void>} A promise that resolves when the file upload is complete. If the upload fails,
    * an error will be thrown.
    *
    * @throws {Error} If there is an issue with the upload, such as network errors, permission issues, or invalid file paths.


### PR DESCRIPTION
![Screenshot from 2025-06-22 20-21-07](https://github.com/user-attachments/assets/e6fb5c9d-7200-4b9d-b2be-cf035c11eb53)
Fixing TypeScript compilation errors that were preventing the test suite from running. The issues were primarily located in the src/tables/ directory and were caused by a missing method in an abstract class and syntax errors in the Table class definition.

#### **Description of Changes:**

1.  **Added Missing `removeTable` Method:**
    * The `Table.removeTable()` method was calling `this.tablesApiClient.removeTable()`, but this method was not defined in the `TablesApiClient` abstract class.
    * To fix this, an abstract `removeTable` method has been added to `tablesApiClient.ts`.
    * The method has been implemented in `tablesRestApiClient.ts`, where it calls the existing `deleteTable` method to maintain consistent functionality.

2.  **Corrected Syntax in `table.ts`:**
    * The `insert` method and its JSDoc comment block were incorrectly placed outside the `Table` class, causing multiple syntax and compilation errors.
    * This has been corrected by moving the entire `insert` method block inside the `Table` class.
    * Malformed comments and extra closing braces have also been removed to ensure the file is syntactically correct.
    
  ```
npm test -- tests/databases/databasesRestApiClient.test.ts
```
![Screenshot from 2025-06-22 20-29-18](https://github.com/user-attachments/assets/d85937de-0d30-440d-ad83-74ea8b3ad6cc)
