### PR TITLE
fix(models): Prevent trailing newlines in generated SQL queries

### DIFF
--- a/src/models/modelsRestApiClient.ts
+++ b/src/models/modelsRestApiClient.ts
@@ -90,11 +90,11 @@ export default class ModelsRestApiClient extends ModelsApiClient {
       if (where.length === 0) {
         return whereClause;
       }
-      whereClause = `WHERE ${where[0]}\n`;
+      whereClause = `WHERE ${where[0]}`;
       if (where.length === 1) {
         return whereClause;
       }
-      whereClause += where
+      whereClause += '\n' + where
         .slice(1)
         .map(
           (o) =>
@@ -104,7 +104,7 @@ export default class ModelsRestApiClient extends ModelsApiClient {
             `AND ${o}`,
         )
         .join('\n');
-    } else {
+    } else if (where) {
       whereClause = `WHERE ${where}`;
     }
     return whereClause;
@@ -272,7 +272,9 @@ export default class ModelsRestApiClient extends ModelsApiClient {
     )}.${mysql.escapeId(name)}.${version}`;
     const whereClause = this.makeWhereClause(options['where'] || []);
     const usingClause = this.makeUsingClause(options['using'] || []);
-    const selectQuery = [selectClause, whereClause, usingClause].join('\n');
+    const selectQuery = [selectClause, whereClause, usingClause]
+      .filter(Boolean)
+      .join('\n');
     const sqlQueryResult = await this.sqlClient.runQuery(selectQuery);
     if (sqlQueryResult.error_message) {
       throw new MindsDbError(sqlQueryResult.error_message);
@@ -320,7 +322,9 @@ export default class ModelsRestApiClient extends ModelsApiClient {
       joinClause,
       whereClause,
       limitClause,
-    ].join('\n');
+    ]
+      .filter(Boolean)
+      .join('\n');
     const sqlQueryResult = await this.sqlClient.runQuery(selectQuery);
     if (sqlQueryResult.error_message) {
       throw new MindsDbError(sqlQueryResult.error_message);
@@ -448,7 +452,9 @@ export default class ModelsRestApiClient extends ModelsApiClient {
     )} FROM ${mysql.escapeId(finetuneOptions['integration'])}`;
     const selectClause = this.makeTrainingSelectClause(finetuneOptions);
     const usingClause = this.makeTrainingUsingClause(finetuneOptions);
-    const query = [finetuneClause, selectClause, usingClause].join('\n');
+    const query = [finetuneClause, selectClause, usingClause]
+      .filter(Boolean)
+      .join('\n');
     const sqlQueryResult = await this.sqlClient.runQuery(query);
     if (sqlQueryResult.error_message) {
       throw new MindsDbError(sqlQueryResult.error_message);


### PR DESCRIPTION

![Screenshot from 2025-06-22 20-34-03](https://github.com/user-attachments/assets/c1ed0362-2549-42c5-81ca-70030e163773)

The `should query model` test case in `tests/models/modelsRestApiClient.test.ts` was failing due to a strict equality check on the generated SQL query. The actual query contained a trailing newline character that was not present in the expected output.

**Root Cause:**
The `queryModel`, `batchQueryModel`, and `finetuneModel` methods in `src/models/modelsRestApiClient.ts` constructed SQL queries by joining an array of clauses with `\n`. If an optional clause (e.g., the `USING` or `LIMIT` clause) was empty, the `.join('\n')` method would still append a newline separator for that empty item, resulting in an incorrect trailing newline at the end of the final query string.

To fix this, a `.filter(Boolean)` has been added to the array of clauses in all three affected methods (`queryModel`, `batchQueryModel`, and `finetuneModel`). This removes any empty or falsy strings from the array *before* they are joined, ensuring that no unnecessary newlines are appended.

```
npm test -- tests/models/modelsRestApiClient.test.ts
```
![Screenshot from 2025-06-22 20-34-38](https://github.com/user-attachments/assets/794253d0-485f-49b7-9ad1-a0c06c7fa64a)

This change aligns these methods with the pattern already used in `trainModel` and `retrainModel` in the same file, ensuring consistent and correct SQL query generation across the module.